### PR TITLE
fix card header actions

### DIFF
--- a/rocket-ui/components/surfaces/card-header/CardHeader.js
+++ b/rocket-ui/components/surfaces/card-header/CardHeader.js
@@ -20,13 +20,15 @@ const CardHeader = ({ variant, actions, title, ...rest }) => {
       }
       disableTypography
       title={
-        title && isValidElement(title) ? (
-          title
-        ) : (
-          <Typography variant='subtitle1' emphasis='bold'>
-            {title}
-          </Typography>
-        )
+        title ? (
+          isValidElement(title) ? (
+            title
+          ) : (
+            <Typography variant='subtitle1' emphasis='bold'>
+              {title}
+            </Typography>
+          )
+        ) : undefined
       }
       {...rest}
     />

--- a/rocket-ui/components/surfaces/card-header/CardHeaderStyles.js
+++ b/rocket-ui/components/surfaces/card-header/CardHeaderStyles.js
@@ -23,13 +23,7 @@ const CardHeader = styled(MuiCardHeader, {
     })
   },
   [`& .MuiCardHeader-action`]: {
-    position: 'absolute',
-    right: '0px',
-    top: '0px',
-    width: '100%',
-    display: 'flex',
-    justifyContent: 'flex-end',
-    padding: '20px 24px'
+    display: 'flex'
   }
 }))
 

--- a/rocket-ui/components/surfaces/card/compositions/BasicCard.composition.js
+++ b/rocket-ui/components/surfaces/card/compositions/BasicCard.composition.js
@@ -4,7 +4,6 @@ import Typography from '@totalsoft_oss/rocket-ui.components.data-display.typogra
 import Button from '@totalsoft_oss/rocket-ui.components.buttons.button'
 import Card from '../Card'
 import IconButton from '@totalsoft_oss/rocket-ui.components.buttons.icon-button'
-import { DonutLarge } from '@mui/icons-material'
 import { LocalActivity } from '@mui/icons-material'
 
 const LearnMoreButton = () => {

--- a/rocket-ui/components/surfaces/card/compositions/BasicCard.composition.js
+++ b/rocket-ui/components/surfaces/card/compositions/BasicCard.composition.js
@@ -3,6 +3,9 @@ import { Grid } from '@mui/material'
 import Typography from '@totalsoft_oss/rocket-ui.components.data-display.typography'
 import Button from '@totalsoft_oss/rocket-ui.components.buttons.button'
 import Card from '../Card'
+import IconButton from '@totalsoft_oss/rocket-ui.components.buttons.icon-button'
+import { DonutLarge } from '@mui/icons-material'
+import { LocalActivity } from '@mui/icons-material'
 
 const LearnMoreButton = () => {
   return (
@@ -63,6 +66,31 @@ export const BasicCard = () => {
               <img src={spaceship} id='img1' alt='spaceship' />
             </Grid> */}
           </Grid>
+        </Card>
+      </Grid>
+      <Grid item md={4}>
+        <Card
+          title='Card Title'
+          actions={[
+            <IconButton tooltip='Tooltip message' type='add' variant='text' size='small' />,
+            <IconButton tooltip='Tooltip message' type='download' variant='text' size='small' />
+          ]}
+          footer={<LearnMoreButton />}
+        >
+          {'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'}
+        </Card>
+      </Grid>
+      <Grid item md={4}>
+        <Card
+          icon={LocalActivity}
+          title='Card Title'
+          actions={[
+            <IconButton tooltip='Tooltip message' type='add' variant='text' size='small' />,
+            <IconButton tooltip='Tooltip message' type='download' variant='text' size='small' />
+          ]}
+          footer={<LearnMoreButton />}
+        >
+          {'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'}
         </Card>
       </Grid>
     </Grid>


### PR DESCRIPTION
Card Header actions were overlapping the content. 
- removed unnecessary styling from header actions 
- added more examples of cards
- fixed the card title, if the 'title' property in empty, render nothing
![image](https://user-images.githubusercontent.com/46926675/222740467-907ce15e-23c4-4051-a703-725c40e264e7.png)
